### PR TITLE
fix nginx X-Forwarded-Proto header

### DIFF
--- a/nginx/gitlab
+++ b/nginx/gitlab
@@ -10,27 +10,25 @@ server {
   listen YOUR_SERVER_IP:80;         # e.g., listen 192.168.1.1:80;
   server_name YOUR_SERVER_FQDN;     # e.g., server_name source.example.com;
   root /home/gitlab/gitlab/public;
-  
+
   # individual nginx logs for this gitlab vhost
   access_log  /var/log/nginx/gitlab_access.log;
   error_log   /var/log/nginx/gitlab_error.log;
-  
+
   location / {
     # serve static files from defined root folder;.
     # @gitlab is a named location for the upstream fallback, see below
     try_files $uri $uri/index.html $uri.html @gitlab;
   }
-  
-  # if a file, which is not found in the root folder is requested, 
+
+  # if a file, which is not found in the root folder is requested,
   # then the proxy pass the request to the upsteam (gitlab unicorn)
   location @gitlab {
     proxy_redirect     off;
-    
-    # you need to change this to "https", if you set "ssl" directive to "on"
-    proxy_set_header   X-FORWARDED_PROTO http;
+    proxy_set_header   X-Forwarded-Proto $scheme;
     proxy_set_header   Host              $http_host;
     proxy_set_header   X-Real-IP         $remote_addr;
-  
+
     proxy_pass http://gitlab;
   }
 }


### PR DESCRIPTION
Also changed hardcoded `http` to `$scheme`. So no need to go back and forth.
