### PR TITLE
Change unicorn config file name from orig to example in the aws script

### DIFF
--- a/install/debian_ubuntu_aws.sh
+++ b/install/debian_ubuntu_aws.sh
@@ -93,7 +93,7 @@ sudo sed -i 's/YOUR_SERVER_IP/'`wget -qO- http://instance-data/latest/meta-data/
 sudo sed -i 's/YOUR_SERVER_FQDN/'`wget -qO- http://instance-data/latest/meta-data/public-hostname`'/' /etc/nginx/sites-available/gitlab # Set public dns domain name.
 
 # Configure Unicorn
-sudo -u gitlab cp /home/gitlab/gitlab/config/unicorn.rb.orig /home/gitlab/gitlab/config/unicorn.rb
+sudo -u gitlab cp /home/gitlab/gitlab/config/unicorn.rb.example /home/gitlab/gitlab/config/unicorn.rb
 
 # Create a Gitlab service
 sudo wget https://raw.github.com/gitlabhq/gitlab-recipes/master/init.d/gitlab -P /etc/init.d/


### PR DESCRIPTION
PragTob made a commit to gitlabhq that renamed unicorn.rb.orig to unicorn.rb.example. This broke my attempted install on EC2, but this should fix the problem.
