### PR TITLE
Update init.d/gitlab

### DIFF
--- a/init.d/gitlab
+++ b/init.d/gitlab
@@ -30,7 +30,7 @@ case "$1" in
 
         echo -n "Starting $DESC: "
         if [ `whoami` = root ]; then
-          sudo -u gitlab sh -l -c "$CD_TO_APP_DIR && $START_DAEMON_PROCESS && $START_RESQUE_PROCESS"
+          sudo -u gitlab bash -l -c "$CD_TO_APP_DIR && $START_DAEMON_PROCESS && $START_RESQUE_PROCESS"
         else
           $CD_TO_APP_DIR && $START_DAEMON_PROCESS && $START_RESQUE_PROCESS
         fi


### PR DESCRIPTION
I changed "sudo -u gitlab sh -l -c ..." to "sudo -u gitlab bash -l -c ...".

The reason for that:
I'm using gitlab with rvm and rvmrc, but 'sh' didn't loaded my .rvm and .rvmrc files, but
bash do it.

It's just a quick fix for my problem, and maybe it helps other while using gitlab with rvm.
