### PR TITLE
Update gitlab init script

### DIFF
--- a/init.d/gitlab
+++ b/init.d/gitlab
@@ -16,41 +16,105 @@
 
 
 APP_ROOT="/home/gitlab/gitlab"
-DAEMON_OPTS="-c $APP_ROOT/config/unicorn.rb -E production -D"
+DAEMON_OPTS="-c $APP_ROOT/config/unicorn.rb -E production"
+PID_PATH="$APP_ROOT/tmp/pids"
+UNICORN_PID="$PID_PATH/unicorn.pid"
+RESQUE_PID="$PID_PATH/resque_worker.pid"
 NAME="unicorn"
 DESC="Gitlab service"
-PID="$APP_ROOT/tmp/pids/unicorn.pid"
-RESQUE_PID="$APP_ROOT/tmp/pids/resque_worker.pid"
+
+check_pid(){
+  if [ -f $UNICORN_PID ]; then
+    PID=`cat $UNICORN_PID`
+    STATUS=`ps aux | grep $PID | grep -v grep | wc -l`
+  else
+    STATUS=0
+    PID=0
+  fi
+}
+
+start() {
+  cd $APP_ROOT
+  check_pid
+  if [ "$PID" -ne 0 -a "$STATUS" -ne 0 ]; then
+    # Program is running, exit with error code 1.
+    echo "Error! $DESC $NAME is currently running!"
+    exit 1
+  else
+    if [ `whoami` = root ]; then
+      sudo -u gitlab -H sh -l -c "nohup bundle exec unicorn_rails $DAEMON_OPTS  > /dev/null  2>&1 &"
+      sudo -u gitlab -H sh -l -c "mkdir -p $PID_PATH && nohup bundle exec rake environment resque:work QUEUE=post_receive,mailer,system_hook RAILS_ENV=production PIDFILE=$RESQUE_PID  > /dev/null  2>&1 &"
+      echo "$DESC started"
+    fi
+  fi
+}
+
+stop() {
+  cd $APP_ROOT
+  check_pid
+  if [ "$PID" -ne 0 -a "$STATUS" -ne 0 ]; then
+    ## Program is running, stop it.
+    kill -QUIT `cat $UNICORN_PID`
+    kill -QUIT `cat $RESQUE_PID`
+    rm "$UNICORN_PID" >> /dev/null
+    rm "$RESQUE_PID" >> /dev/null
+    echo "$DESC stopped"
+  else
+    ## Program is not running, exit with error.
+    echo "Error! $DESC not started!"
+    exit 1
+  fi
+}
+
+restart() {
+  cd $APP_ROOT
+  check_pid
+  if [ "$PID" -ne 0 -a "$STATUS" -ne 0 ]; then
+    echo -n "Restarting $DESC: "
+    kill -USR2 `cat $UNICORN_PID`
+    kill -USR2 `cat $RESQUE_PID`
+    echo "$NAME."
+  else
+    echo "Error, $NAME not running!"
+    exit 1
+  fi
+}
+
+status() {
+  cd $APP_ROOT
+  check_pid
+  if [ "$PID" -ne 0 -a "$STATUS" -ne 0 ]; then
+    echo "$DESC with PID $PID is running."
+  else
+    echo "$DESC is not running."
+    exit 1
+  fi
+}
+
+## Check to see if we are running as root first.
+## Found at http://www.cyberciti.biz/tips/shell-root-user-check-script.html
+if [ "$(id -u)" != "0" ]; then
+    echo "This script must be run as root"
+    exit 1
+fi
 
 case "$1" in
   start)
-        CD_TO_APP_DIR="cd $APP_ROOT"
-        START_DAEMON_PROCESS="bundle exec unicorn_rails $DAEMON_OPTS"
-        START_RESQUE_PROCESS="./resque.sh"
-
-        echo -n "Starting $DESC: "
-        if [ `whoami` = root ]; then
-          sudo -u gitlab sh -l -c "$CD_TO_APP_DIR && $START_DAEMON_PROCESS && $START_RESQUE_PROCESS"
-        else
-          $CD_TO_APP_DIR && $START_DAEMON_PROCESS && $START_RESQUE_PROCESS
-        fi
-        echo "$NAME."
+        start
         ;;
   stop)
-        echo -n "Stopping $DESC: "
-        kill -QUIT `cat $PID`
-        kill -QUIT `cat $RESQUE_PID`
-        echo "$NAME."
+        stop
         ;;
   restart)
-        echo -n "Restarting $DESC: "
-        kill -USR2 `cat $PID`
-        echo "$NAME."
+        restart
         ;;
-  reload)
+  reload|force-reload)
         echo -n "Reloading $DESC configuration: "
         kill -HUP `cat $PID`
         echo "$NAME."
+        ;;
+  status)
+        status
         ;;
   *)
         echo "Usage: $NAME {start|stop|restart|reload}" >&2


### PR DESCRIPTION
When deploying with Chef we encountered problems with the existing init script:
1.  It didn't support the status command.
2. The error handling and exit codes on errors could be improved.
3. The unicorn script redirects STDOUT to /dev/null causing Chef client to stop displaying the installation progress.

This pull request fixes the above and refactored the functions in separate commands.

Let us know if you would like anything changed.
