### PR TITLE
alternative solution for getting Nginx to work with gitlab on Centos

### DIFF
--- a/nginx/ReadMe-CentOS.md
+++ b/nginx/ReadMe-CentOS.md
@@ -7,3 +7,7 @@ Set user gitlab in group root for user in nginx.conf:
     #user              nginx;
     user              gitlab root;
 
+Or:
+
+    sudo /usr/sbin/usermod -a -G gitlab nginx
+    sudo /bin/chmod g+rx /home/gitlab/


### PR DESCRIPTION
This way you can keep nginx running in it's own user
 and access gitlab files.
