### PR TITLE
Correct apache2 proxy use

### DIFF
--- a/apache/gitlab
+++ b/apache/gitlab
@@ -10,6 +10,7 @@
 	
 	ProxyPass / http://127.0.0.1:3000/
 	ProxyPassReverse / http://127.0.0.1:3000/
+	ProxyPreserveHost On
 
 	CustomLog /var/log/apache2/gitlab/access.log combined
 	ErrorLog  /var/log/apache2/gitlab/error.log
@@ -25,6 +26,7 @@
 
 	ProxyPass / http://127.0.0.1:3000/
 	ProxyPassReverse / http://127.0.0.1:3000/
+	ProxyPreserveHost On
 
 	CustomLog /var/log/apache2/gitlab/access.log combined
 	ErrorLog  /var/log/apache2/gitlab/error.log


### PR DESCRIPTION
Missing `ProxyPreserveHost On` caused not working proxy on Debian Squeeze.
Fixes issue #45.
