### PR TITLE
CentOS_6.md : missing a "service redis start" 

### DIFF
--- a/install/CentOS_6.md
+++ b/install/CentOS_6.md
@@ -94,6 +94,7 @@ Just make sure it is started at the next reboot
 *logged in as root*
 
     chkconfig redis on
+    service redis start
 
 ## Configure mysql
 Make sure it is started at the next reboot and start it immediately so we can configure it.


### PR DESCRIPTION
rake gitlab:app:setup fails when redis is not running. Error thrown is "Error connecting to
Redis on 127.0.0.1:6379 (ECONNREFUSED)" . This adds a simple "service redis start" to 
the recipe.
