### PR TITLE
CentOS satellites update

### DIFF
--- a/install/CentOS_6.md
+++ b/install/CentOS_6.md
@@ -455,6 +455,7 @@ used for the `email.from` setting in `config/gitlab.yml`)
     bundle exec rake gitlab:app:setup RAILS_ENV=production
 
 The previous command will ask you for the root password of the mysql database and create the defined database and user.
+
 Create the satellites (needed for Automerge)
 
 *logged in as **gitlab***


### PR DESCRIPTION
I found that auto merge was not working because the satellites had not been installed. 

I effectively made the steps from the troubleshooting guide part of the installation manual for CentOS.
