### PR TITLE
[init script] GitLab 4.2 - CentOS 6.3

### DIFF
--- a/init.d/gitlab-centos
+++ b/init.d/gitlab-centos
@@ -2,7 +2,7 @@
 #
 # GitLab
 # Maintainer: @elvanja, @troyanov
-# App Version: 4.0
+# App Version: 4.2
 
 # chkconfig: 2345 82 55
 # processname: unicorn


### PR DESCRIPTION
I created the needed init.d script for gitlab 4.2 for CentOS 6.3, just in case someone wants to upgrade to latest version.
