### PR TITLE
Fixes http redirects on https only vhost

### DIFF
--- a/apache/gitlab
+++ b/apache/gitlab
@@ -25,7 +25,7 @@
 	#SSLCertificateChainFile /etc/apache2/ssl/cacert.pem
 
 	# Uncomment the following line to prevent redirects to http on https only vhosts
-        #RequestHeader set X-Forwarded-Proto "https"
+	#RequestHeader set X-Forwarded-Proto "https"
 
 	ProxyPass / http://127.0.0.1:3000/
 	ProxyPassReverse / http://127.0.0.1:3000/


### PR DESCRIPTION
Adds an optional apache vhost configuration;

```
 RequestHeader set X-Forwarded-Proto "https"
```
