### PR TITLE
Fix APP_ROOT variable to match the path that is mentioned in the install instructions

### DIFF
--- a/init.d/gitlab
+++ b/init.d/gitlab
@@ -15,7 +15,7 @@
 ### END INIT INFO
 
 
-APP_ROOT="/home/git/gitlab"
+APP_ROOT="/home/gitlab/gitlab"
 DAEMON_OPTS="-c $APP_ROOT/config/unicorn.rb -E production"
 PID_PATH="$APP_ROOT/tmp/pids"
 UNICORN_PID="$PID_PATH/unicorn.pid"


### PR DESCRIPTION
Fix APP_ROOT to match the path that is mentioned in the install instructions. Otherwise this script won't really work.

NOTE: Assuming this change will be pulled in, we'd have to check the `gitlab:check` rake task that is responsible for ensuring that the init script is up to date.
