### PR TITLE
database.yml.example was not found

### DIFF
--- a/install/debian_ubuntu_aws.sh
+++ b/install/debian_ubuntu_aws.sh
@@ -69,7 +69,7 @@ sudo gem install bundler
 sudo su -l gitlab -c "git clone git://github.com/gitlabhq/gitlabhq.git gitlab" # Using master everywhere.
 sudo su -l gitlab -c "cd gitlab && mkdir tmp"
 sudo su -l gitlab -c "cd gitlab/config && cp gitlab.yml.example gitlab.yml"
-sudo su -l gitlab -c "cd gitlab/config && cp database.yml.example database.yml"
+sudo su -l gitlab -c "cd gitlab/config && cp database.yml.mysql database.yml"
 sudo sed -i 's/"secure password"/"'$userPassword'"/' /home/gitlab/gitlab/config/database.yml # Insert the mysql root password.
 sudo su -l gitlab -c "cd gitlab && bundle install --without development test --deployment"
 sudo su -l gitlab -c "cd gitlab && bundle exec rake gitlab:app:setup RAILS_ENV=production"


### PR DESCRIPTION
Looks like database.yml.example in gitlab is now either database.yml.mysql or database.yml.postgresql. I've set this to database.yml.mysql.
