### PR TITLE
Version 5

### DIFF
--- a/init.d/gitlab-centos
+++ b/init.d/gitlab-centos
@@ -2,7 +2,7 @@
 #
 # GitLab
 # Maintainer: @elvanja, @troyanov, @eiyaya
-# App Version: 4.1
+# App Version: 5.0
 
 # chkconfig: 2345 82 55
 # processname: unicorn
@@ -20,7 +20,7 @@
 NAME=gitlab
 
 # The username and path to the gitlab source
-USER=$NAME
+USER=git
 APP_PATH=/home/$USER/gitlab
 
 # The PID and LOCK files used by unicorn and sidekiq


### PR DESCRIPTION
Updating the init.d script to use the user 'git' instead of 'gitlab'. According to documentation of version 5.0 and up.
