### PR TITLE
- swapping uid=git as per 5.0 install doc.

### DIFF
--- a/init.d/gitlab-centos
+++ b/init.d/gitlab-centos
@@ -20,7 +20,7 @@
 NAME=gitlab
 
 # The username and path to the gitlab source
-USER=$NAME
+USER=git
 APP_PATH=/home/$USER/gitlab
 
 # The PID and LOCK files used by unicorn and sidekiq


### PR DESCRIPTION
Updates to the CentOS /etc/init.d/gitlab-centos script. Substituting the gitlabhq uid ("git") as per the 5.0 install guide.
