### PR TITLE
Fix not starting sidekiq process if "gitlab restart".

### DIFF
--- a/init.d/gitlab
+++ b/init.d/gitlab
@@ -74,7 +74,7 @@ restart() {
   if [ "$PID" -ne 0 -a "$STATUS" -ne 0 ]; then
     echo "Restarting $DESC..."
     kill -USR2 `cat $WEB_SERVER_PID`
-    sudo -u git -H bash -l -c "mkdir -p $PID_PATH && $STOP_SIDEKIQ  > /dev/null  2>&1 &"
+    sudo -u git -H bash -l -c "mkdir -p $PID_PATH && $STOP_SIDEKIQ  > /dev/null  2>&1"
     if [ `whoami` = root ]; then
       sudo -u git -H bash -l -c "mkdir -p $PID_PATH && $START_SIDEKIQ  > /dev/null  2>&1 &"
     fi


### PR DESCRIPTION
It needs to wait for completing STOP_SIDEKIQ before START_SIDEKIQ.
refs #52
