### PR TITLE
Apache: Update proxy URL to use PUMA defaults (0.0.0.0:9292)

### DIFF
--- a/apache/gitlab
+++ b/apache/gitlab
@@ -7,9 +7,9 @@
 	#RewriteEngine   on
 	#RewriteCond     %{SERVER_PORT} ^80$
 	#RewriteRule     ^(.*)$ https://%{SERVER_NAME}$1 [L,R]
-	
-	ProxyPass / http://127.0.0.1:3000/
-	ProxyPassReverse / http://127.0.0.1:3000/
+
+	ProxyPass / http://0.0.0.0:9292/
+	ProxyPassReverse / http://0.0.0.0:9292/
 	ProxyPreserveHost On
 
 	CustomLog /var/log/apache2/gitlab/access.log combined
@@ -24,8 +24,8 @@
 	SSLCertificateKeyFile /etc/apache2/ssl/server.key
 	#SSLCertificateChainFile /etc/apache2/ssl/cacert.pem
 
-	ProxyPass / http://127.0.0.1:3000/
-	ProxyPassReverse / http://127.0.0.1:3000/
+	ProxyPass / http://0.0.0.0:9292/
+	ProxyPassReverse / http://0.0.0.0:9292/
 	ProxyPreserveHost On
 
 	CustomLog /var/log/apache2/gitlab/access.log combined


### PR DESCRIPTION
as apache's mod_proxy doesn't support sockets [1].
This obviously implies that `config/puma.rb` is configured accordingly (and assumes gitlab v5.1):

```
# Bind the server to “url”. “tcp://”, “unix://” and “ssl://” are the only
# accepted protocols.
#
# The default is “tcp://0.0.0.0:9292”.
#
bind 'tcp://0.0.0.0:9292'
#bind "unix://#{application_path}/tmp/sockets/gitlab.socket"
```

[1] http://httpd.apache.org/docs/2.2/mod/mod_proxy.html
