### PR TITLE
Updated https root to match installation manual; some other minor changes

### DIFF
--- a/nginx/gitlab-https
+++ b/nginx/gitlab-https
@@ -20,7 +20,7 @@ server {
     server_name YOUR_SERVER_FQDN;
     server_tokens off;
     root /nowhere;
-    rewrite ^ $server_name$request_uri permanent;
+    rewrite ^ https://$server_name$request_uri permanent;
 }
 server {
     listen 443;


### PR DESCRIPTION
Fixes https root to go into /home/git/gitlab/public, otherwise attachments will show 404.

Updated rewrite rule, so it won't point to someone else's install of GitLab.

There is [no option TLSv2 for ssl_protocols in nginx](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols), updated to fix error. 

Match config to http version. 
