### PR TITLE
In gitlab-https, fix rewrite url and the upstream url for 5.0

### DIFF
--- a/nginx/gitlab-https
+++ b/nginx/gitlab-https
@@ -1,6 +1,6 @@
 # GITLAB
 # Maintainer: @yin8086
-# App Version: 4.1
+# App Version: 5.0
 
 # Modified from nginx http version
 # Modified from http://blog.phusion.nl/2012/04/21/tutorial-setting-up-gitlab-on-debian-6/
@@ -10,7 +10,7 @@
 # $ sudo chmod o-r gitlab.key
 
 upstream gitlab {
-  server unix:/home/gitlab/gitlab/tmp/sockets/gitlab.socket;
+  server unix:/home/git/gitlab/tmp/sockets/gitlab.socket;
 }
 
 # This is a normal HTTP host which redirects all traffic to the HTTPS host.
@@ -19,13 +19,13 @@ server {
     server_name Domain_NAME;
     server_tokens off;
     root /nowhere;
-    rewrite ^ https://gitlab.stardrad.com$request_uri permanent;
+    rewrite ^ https://Domain_NAME$request_uri permanent;
 }
 server {
     listen 443;
     server_name Domain_NAME;
     server_tokens off;
-    root /home/gitlab/gitlab/public;
+    root /home/git/gitlab/public;
 
     ssl on;
     ssl_certificate gitlab.crt;


### PR DESCRIPTION
In 5.0, some paths have changed, so I changed them to the new version. And I made a mistake in the rewrite part, I put my own url in the rewrite part. Sorry for that, now i fix it.
