### PR TITLE
Save original $PATH and restore it after executing '/etc/rc.d/init.d/functions'

### DIFF
--- a/init.d/gitlab-centos
+++ b/init.d/gitlab-centos
@@ -13,8 +13,16 @@
 # https://github.com/gitlabhq/gitlabhq/issues/1049#issuecomment-8386882
 # https://gist.github.com/3062860
 
+# Save original $PATH
+# /etc/rc.d/init.d/functions resets $PATH to default(/sbin:/usr/sbin:/bin:/usr/bin).
+# Consequently, rvm and compiled ruby with custom path (which isn't /usr/bin) cannot be executed.
+ORIGINAL_PATH=$PATH
+
 # Include RedHat function library
 . /etc/rc.d/init.d/functions
+
+# Restore original $PATH 
+PATH=$ORIGINAL_PATH
 
 # The name of the service
 NAME=git


### PR DESCRIPTION
/etc/rc.d/init.d/functions resets `$PATH` to default(`/sbin:/usr/sbin:/bin:/usr/bin`). Consequently, rvm and compiled ruby with custom path (which isn't `/usr/bin`) cannot be executed.
