### PR TITLE
More secure SSL and defined errordocuments

### DIFF
--- a/web-server/apache/gitlab.conf
+++ b/web-server/apache/gitlab.conf
@@ -21,7 +21,7 @@
   SSLCipherSuite SSLv3:TLSv1:+HIGH:!SSLv2:!MD5:!MEDIUM:!LOW:!EXP:!ADH:!eNULL:!aNULL
   SSLCertificateFile    /etc/httpd/ssl.crt/gitlab.example.com.crt
   SSLCertificateKeyFile /etc/httpd/ssl.key/gitlab.example.com.key
-  SSLCACertificateFile  /etc/httpd/ssl.crt/incommon-ca.crt
+  SSLCACertificateFile  /etc/httpd/ssl.crt/your-ca.crt
 
   ServerName gitlab.example.com
   ServerSignature Off


### PR DESCRIPTION
Now ErrorDocuments use GitLab error documents.  When the backend
service is down (i.e. Unicorn) then Apache will show a GitLab
maintenance page (error 503).  Other errors (404, 422, 500) are
also included in the rewrite.

Updated SSL ciphers so that only the strongest SSL ciphers are
allowed.  This is primarily a security update for allowed
encryption ciphers.

If you would like to test encryption strength on your own servers then go ahead and grab a copy of nmap v6.0+ and run the following command.

```
nmap --script ssl-cert,ssl-enum-ciphers -p 443 gitlab.example.com
```
