### PR TITLE
[CentOS] Simpler firewall instructions

### DIFF
--- a/install/centos/README.md
+++ b/install/centos/README.md
@@ -518,25 +518,8 @@ Start apache:
 ## 8. Configure the firewall
 
 Poke an iptables hole so users can access the httpd (http and https ports) and ssh.
-The quick way is to put this in the file called `/etc/sysconfig/iptables`:
 
-```
-# Firewall configuration written by system-config-firewall
-# Manual customization of this file is not recommended.
-*filter
-:INPUT ACCEPT [0:0]
-:FORWARD ACCEPT [0:0]
-:OUTPUT ACCEPT [0:0]
--A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
--A INPUT -p icmp -j ACCEPT
--A INPUT -i lo -j ACCEPT
--A INPUT -m state --state NEW -m tcp -p tcp --dport 22 -j ACCEPT
--A INPUT -m state --state NEW -m tcp -p tcp --dport 80 -j ACCEPT
--A INPUT -m state --state NEW -m tcp -p tcp --dport 443 -j ACCEPT
--A INPUT -j REJECT --reject-with icmp-host-prohibited
--A FORWARD -j REJECT --reject-with icmp-host-prohibited
-COMMIT
-```
+    lokkit -s http -s https -s ssh
 
 Restart the service for the changes to take effect:
 


### PR DESCRIPTION
Manual editing of iptables is not required nor recommended. The documentation as-is will not open IPv6 ports and might conflict with other services on the same server. It is better to use lokkit, a command line tool to edit the firewall settings. This will edit both iptables configuration files and also the firewall configuration, so that system-config-firewall is updated accordingly. Added bonus: enabling/disabling the firewall using system-config-firewall will not destroy the settings.
