### PR TITLE
Simplified & improved apache proxy config for SSL

### DIFF
--- a/web-server/apache/gitlab-ssl.conf
+++ b/web-server/apache/gitlab-ssl.conf
@@ -14,7 +14,7 @@
 
   RewriteEngine on
   RewriteCond %{HTTPS} !=on
-  RewriteRule ^(.*) https://%{SERVER_NAME}$1 [R,L]
+  RewriteRule .* https://%{SERVER_NAME}%{REQUEST_URI} [NE,R,L]
 </VirtualHost>
 
 <VirtualHost *:443>


### PR DESCRIPTION
Previously there was an unnecessary redirect before & after sign-in where the browser would be briefly redirected over http.  This new configuration eliminates that leak, and is easier to read.
