### PR TITLE
make centos gitlab-* init scripts more LSB compliant by returning a status return code

### DIFF
--- a/init/sysvinit/centos/gitlab-puma
+++ b/init/sysvinit/centos/gitlab-puma
@@ -25,7 +25,8 @@ ORIGINAL_PATH=$PATH
 PATH=$ORIGINAL_PATH
 
 # The name of the service
-NAME=git
+NAME=${0##*/}
+
 
 # The username and path to the gitlab source
 USER=git
@@ -93,11 +94,18 @@ restart() {
 
 get_status() {
   status -p $UPID puma
+  puma=$?
+
   status -p $SPID sidekiq
+  sidekiq=$?
+
+  retval=$puma || $sidekiq
+  return $retval
 }
 
 query_status() {
   get_status >/dev/null 2>&1
+  return $?
 }
 
 case "$1" in
@@ -114,6 +122,7 @@ case "$1" in
     ;;
   status)
     get_status
+    exit $?
     ;;
   *)
     N=/etc/init.d/$NAME

--- a/init/sysvinit/centos/gitlab-unicorn
+++ b/init/sysvinit/centos/gitlab-unicorn
@@ -25,7 +25,8 @@ ORIGINAL_PATH=$PATH
 PATH=$ORIGINAL_PATH
 
 # The name of the service
-NAME=git
+NAME=${0##*/}
+
 
 # The username and path to the gitlab source
 USER=git
@@ -93,11 +94,18 @@ restart() {
 
 get_status() {
   status -p $UPID unicorn
+  unicorn=$?
+
   status -p $SPID sidekiq
+  sidekiq=$?
+
+  retval=$unicorn || $sidekiq
+  return $retval
 }
 
 query_status() {
   get_status >/dev/null 2>&1
+  return $?
 }
 
 case "$1" in
@@ -114,6 +122,7 @@ case "$1" in
     ;;
   status)
     get_status
+    exit $?
     ;;
   *)
     N=/etc/init.d/$NAME


### PR DESCRIPTION
I made two fundamental changes: The first is for the init scripts to get the name of the service from the init script file name used to invoke the service. The second is to return a status return code if sidekiq or puma/unicorn is not running. This will enable tools like puppet to properly detect if the service is running or not and it if needs to start the service.
