### PR TITLE
[Guide] GitLab 6.x - CentOs 6.4 - Fix for the CERT error when wget fetches GPG key.

### DIFF
--- a/install/centos/README.md
+++ b/install/centos/README.md
@@ -76,7 +76,7 @@ As part of the Fedora packaging community, EPEL packages are 100% free/libre ope
 
 Download the GPG key for EPEL repository from [fedoraproject][keys] and install it on your system:
 
-    sudo wget -O /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6 https://fedoraproject.org/static/0608B895.txt
+    sudo wget -O /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6 https://www.fedoraproject.org/static/0608B895.txt
     sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6
 
 Verify that the key got installed successfully:


### PR DESCRIPTION
sudo wget -O /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6 https://fedoraproject.org/static/0608B895.txt 

--2013-10-17 09:11:36--  https://fedoraproject.org/static/0608B895.txt
Resolving fedoraproject.org... 66.135.62.201, 67.203.2.67, 140.211.169.197, ...
Connecting to fedoraproject.org|66.135.62.201|:443... connected.
ERROR: certificate common name “*.fedoraproject.org” doesn’t match requested host name “fedoraproject.org”.
To connect to fedoraproject.org insecurely, use ‘--no-check-certificate’.

substitute fedoraproject.org for www.fedoraproject.org which provides a 301 redirect to fedoraproject.org, but still covered by their wildcard SSL cert.
