### PR TITLE
Fixing CentOS init.d as after upgrading to 6.2, sidekiq does not start

### DIFF
--- a/init/sysvinit/centos/gitlab-unicorn
+++ b/init/sysvinit/centos/gitlab-unicorn
@@ -49,14 +49,14 @@ start() {
 
   # Start unicorn
   echo -n $"Starting unicorn: "
-  daemon --pidfile=$UPID --user=$USER "$RUBY_PATH_PATCH RAILS_ENV=production bundle exec unicorn_rails $OPTS"
+  daemon --pidfile=$UPID --user=$USER "$RUBY_PATH_PATCH RAILS_ENV=production script/web start"
   unicorn=$?
   [ $unicorn -eq 0 ] && touch $ULOCK
   echo
 
   # Start sidekiq
   echo -n $"Starting sidekiq: "
-  daemon --pidfile=$SPID --user=$USER "$RUBY_PATH_PATCH RAILS_ENV=production bundle exec rake sidekiq:start"
+  daemon --pidfile=$SPID --user=$USER "$RUBY_PATH_PATCH RAILS_ENV=production script/background_jobs start"
   sidekiq=$?
   [ $sidekiq -eq 0 ] && touch $SLOCK
   echo


### PR DESCRIPTION
After upgrading from 6.1 to 6.2 the init.d script broke down - the sidekiq was not starting.

The error was - sidekiq:start rake command was not found.
