### PR TITLE
updated service files for use with Gitlab 6.2

### DIFF
--- a/init/systemd/README.md
+++ b/init/systemd/README.md
@@ -30,7 +30,7 @@ Start the services:
 
 Enable them to start at boot:
 
-    sudo systemctl enable gitlab-sidekiq gitlab-unicorn
+    sudo systemctl enable gitlab.target gitlab-sidekiq gitlab-unicorn
 
 ## Notes
 

--- a/init/systemd/gitlab-sidekiq.service
+++ b/init/systemd/gitlab-sidekiq.service
@@ -1,16 +1,13 @@
 #####################################################
 #
 # GitLab version    : 5.x - 6.x
-# Contributors      : davispuh, mtorromeo, axilleas
+# Contributors      : davispuh, mtorromeo, axilleas, boeserwolf91
 # Downloaded from   : https://github.com/gitlabhq/gitlab-recipes/tree/master/init/systemd
 #
 ####################################################
 
 [Unit]
 Description=GitLab Sidekiq Worker
-Requires=redis.service
-After=syslog.target network.target redis.service
-Wants=mysqld.service
 
 [Service]
 Type=forking
@@ -20,8 +17,8 @@ Environment=RAILS_ENV=production
 SyslogIdentifier=gitlab-sidekiq
 PIDFile=/home/git/gitlab/tmp/pids/sidekiq.pid
 
-ExecStart=/usr/bin/bundle exec rake sidekiq:start
-ExecStop=/usr/bin/bundle exec rake sidekiq:stop
+ExecStart=/usr/bin/bundle exec "sidekiq -q post_receive,mailer,system_hook,project_web_hook,gitlab_shell,common,default -e production -P tmp/pids/sidekiq.pid -d -L log/sidekiq.log >> log/sidekiq.log 2>&1"
+ExecStop=/usr/bin/bundle exec "sidekiqctl stop /home/git/gitlab/tmp/pids/sidekiq.pid >> /home/git/gitlab/log/sidekiq.log 2>&1"
 
 [Install]
 WantedBy=gitlab.target

--- a/init/systemd/gitlab-unicorn.service
+++ b/init/systemd/gitlab-unicorn.service
@@ -1,15 +1,13 @@
 #####################################################
 #
 # GitLab version    : 5.x - 6.x
-# Contributors      : davispuh, mtorromeo, axilleas
+# Contributors      : davispuh, mtorromeo, axilleas, boeserwolf91
 # Downloaded from   : https://github.com/gitlabhq/gitlab-recipes/tree/master/init/systemd
 #
 ####################################################
 
 [Unit]
 Description=GitLab Unicorn Server
-Requires=redis.service
-After=network.target mysqld.service redis.service
 
 [Service]
 User=git
@@ -19,6 +17,8 @@ SyslogIdentifier=gitlab-unicorn
 PIDFile=/home/git/gitlab/tmp/pids/unicorn.pid
 
 ExecStart=/usr/bin/bundle exec "unicorn_rails -c /home/git/gitlab/config/unicorn.rb -E production"
+ExecStop=/usr/bin/kill -QUIT $MAINPID
+ExecReload=/usr/bin/kill -USR2 $MAINPID
 
 [Install]
 WantedBy=gitlab.target

--- a/init/systemd/gitlab.target
+++ b/init/systemd/gitlab.target
@@ -1,13 +1,15 @@
 ###########################################################################################
 #
 # GitLab version    : 5.x - 6.x
-# Contributors      : davispuh, mtorromeo, axilleas
+# Contributors      : davispuh, mtorromeo, axilleas, boeserwolf91
 # Downloaded from   : https://github.com/gitlabhq/gitlab-recipes/tree/master/init/systemd 
 #
 ###########################################################################################
 
 [Unit]
 Description=GitLab - Self Hosted Git Management
+Requires=redis.service mysqld.service
+After=redis.service mysqld.service syslog.target network.target
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I updated the service file. The sidekiq works with Gitlab 6.2. now. 

In addition I abstracted the requires and after services into the gitlab.target and I fixed the readme. The services shouldn't start at boot if the gitlab.target isn't enabled. 
