### PR TITLE
Change the way sidekiq start in init script for CentOS

### DIFF
--- a/init/sysvinit/centos/gitlab-puma
+++ b/init/sysvinit/centos/gitlab-puma
@@ -56,7 +56,7 @@ start() {
 
   # Start sidekiq
   echo -n $"Starting sidekiq: "
-  daemon --pidfile=$SPID --user=$USER "$RUBY_PATH_PATCH RAILS_ENV=production bundle exec rake sidekiq:start"
+  daemon --pidfile=$SPID --user=$USER "$RUBY_PATH_PATCH RAILS_ENV=production script/background_jobs start"
   sidekiq=$?
   [ $sidekiq -eq 0 ] && touch $SLOCK
   echo

--- a/init/sysvinit/centos/gitlab-unicorn
+++ b/init/sysvinit/centos/gitlab-unicorn
@@ -49,7 +49,7 @@ start() {
 
   # Start unicorn
   echo -n $"Starting unicorn: "
-  daemon --pidfile=$UPID --user=$USER "$RUBY_PATH_PATCH RAILS_ENV=production bundle exec unicorn_rails $OPTS"
+  daemon --pidfile=$UPID --user=$USER "$RUBY_PATH_PATCH RAILS_ENV=production script/background_jobs start"
   unicorn=$?
   [ $unicorn -eq 0 ] && touch $ULOCK
   echo


### PR DESCRIPTION
Fix the error when try to start gitlab:

```
Don't know how to build task 'sidekiq:start
```

See https://github.com/gitlabhq/gitlabhq/issues/5426 for more information.
