### PR TITLE
Apache config - better based on SSL config

### DIFF
--- a/web-server/apache/gitlab.conf
+++ b/web-server/apache/gitlab.conf
@@ -3,28 +3,27 @@
 #Module dependencies
 #  mod_rewrite
 #  mod_proxy
-#  mod_proxy_balancer
 #  mod_proxy_http
 <VirtualHost *:80>
   ServerName gitlab.example.com
   ServerSignature Off
+
+  ProxyPreserveHost On
+
+  <Location />
+    Order deny,allow
+    Allow from all
+
+    ProxyPassReverse http://127.0.0.1:8080
+    ProxyPassReverse http://gitlab.example.com/
+  </Location>
 
   #apache equivalent of nginx try files
   # http://serverfault.com/questions/290784/what-is-apaches-equivalent-of-nginxs-try-files
   # http://stackoverflow.com/questions/10954516/apache2-proxypass-for-rails-app-gitlab
   RewriteEngine on
   RewriteCond %{DOCUMENT_ROOT}/%{REQUEST_FILENAME} !-f
-  RewriteRule ^/(.*)$ balancer://unicornservers%{REQUEST_URI} [P,QSA,L]
-
-  ProxyPreserveHost On
-  ProxyPass /uploads !
-  ProxyPass /error !
-
-  <Proxy balancer://unicornservers>
-    BalancerMember http://127.0.0.1:8080
-    ProxyPassReverse http://127.0.0.1:8080
-    ProxyPassReverse http://gitlab.example.com:8080
-  </Proxy>
+  RewriteRule .* http://127.0.0.1:8080%{REQUEST_URI} [P,QSA]
 
   # needed for downloading attachments
   DocumentRoot /home/git/gitlab/public
@@ -34,11 +33,6 @@
   ErrorDocument 422 /422.html
   ErrorDocument 500 /500.html
   ErrorDocument 503 /deploy.html
-
-  <Location />
-    Order deny,allow
-    Allow from all
-  </Location>
 
   LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b" common_forwarded
   ErrorLog  /var/log/httpd/logs/gitlab.example.com_error.log


### PR DESCRIPTION
This is a better plain text proxy config which is based on the `gitlab-ssl.conf`.
