### PR TITLE
Incorporate fix for incorrect http redirect

### DIFF
--- a/web-server/apache/gitlab-ssl.conf
+++ b/web-server/apache/gitlab-ssl.conf
@@ -45,6 +45,7 @@
   RewriteEngine on
   RewriteCond %{DOCUMENT_ROOT}/%{REQUEST_FILENAME} !-f
   RewriteRule .* http://127.0.0.1:8080%{REQUEST_URI} [P,QSA]
+  RequestHeader set X_FORWARDED_PROTO 'https'
 
   # needed for downloading attachments
   DocumentRoot /home/git/gitlab/public


### PR DESCRIPTION
Incorporates fix from https://github.com/gitlabhq/gitlabhq/issues/715 to make gitlab properly redirect to https instead of http when configured for https
