### PR TITLE
Update Centos 6.4 guide to obtain git via RPM instead of compilation

### DIFF
--- a/install/centos/README.md
+++ b/install/centos/README.md
@@ -354,9 +354,6 @@ cp config/gitlab.yml.example config/gitlab.yml
 # Replace your_domain_name with the fully-qualified domain name of your host serving GitLab
 sed -i 's|localhost|your_domain_name|g' config/gitlab.yml
 
-# Change git's path to point to /usr/local/bin/git
-sed -i 's|/usr/bin/git|/usr/local/bin/git|' config/gitlab.yml
-
 # Make sure GitLab can write to the log/ and tmp/ directories
 chown -R git log/
 chown -R git tmp/


### PR DESCRIPTION
Recently I installed Gitlab 6.2 on a CentOS6.4 system using the excellent "GitLab recipe" that has been put together.  I knew I could get a modern git RPM package from a trusted repository instead of compiling it, so I've updated the instructions which simplifies things a bit.  Everything worked out well with my GitLab install using the alternate git installation route.

Sidenote: I'm working on some Ansible scripts to auto-magically deploy GitLab at https://github.com/psftw/simple-ansible but it is not ready for prime time yet.
