### PR TITLE
CentOS Install - PUIAS repo

### DIFF
--- a/install/centos/README.md
+++ b/install/centos/README.md
@@ -92,7 +92,9 @@ The [PUIAS Computational][PUIAS] repository is a part of [PUIAS/Springdale Linux
 a custom Red Hat&reg; distribution maintained by [Princeton University][PU] and the
 [Institute for Advanced Study][IAS].  We take advantage of the PUIAS
 Computational repository to obtain a git v1.8.x package since the base CentOS
-repositories only provide v1.7.1 which is not compatible with GitLab. Although the PUIAS Computational repo offers an RPM, it requires the other PUIAS repos as a dependency, so you'll have to add it manually.
+repositories only provide v1.7.1 which is not compatible with GitLab.
+Although the PUIAS offers an RPM to install the repo, it requires the
+other PUIAS repos as a dependency, so you'll have to add it manually.
 
 Create /etc/yum.repos.d/PUIAS_6_computational.repo and add the following lines:
 


### PR DESCRIPTION
I got the following errors when trying to add the PUIAS computational repo:

```
[cdayjr@git ~]$ sudo rpm -Uvh http://puias.math.ias.edu/data/puias/6/x86_64/os/Packages/springdale-computational-6-2.sdl6.10.noarch.rpm
Retrieving http://puias.math.ias.edu/data/puias/6/x86_64/os/Packages/springdale-computational-6-2.sdl6.10.noarch.rpm
warning: /var/tmp/rpm-tmp.ILvW7h: Header V3 RSA/SHA256 Signature, key ID 41a40948: NOKEY
error: Failed dependencies:
    /etc/pki/rpm-gpg/RPM-GPG-KEY-puias is needed by springdale-computational-6-2.sdl6.10.noarch
    springdale-addons is needed by springdale-computational-6-2.sdl6.10.noarch
    springdale-core is needed by springdale-computational-6-2.sdl6.10.noarch
    springdale-release is needed by springdale-computational-6-2.sdl6.10.noarch
```

I got this working completely fine by adding the repo manually based on the information on [this page](http://springdale.math.ias.edu/wiki/YumRepositories6#Computational) and getting the key from [here](http://springdale.math.ias.edu/data/puias/6/x86_64/os/). Hopefully this will help some people out.
