### PR TITLE
Adding a init.d script without unicorn or puma, just sidekiq

### DIFF
--- a/init/sysvinit/centos/gitlab-only-sidekiq
+++ b/init/sysvinit/centos/gitlab-only-sidekiq
@@ -6,7 +6,7 @@
 
 # chkconfig: 2345 82 55
 # processname: sidekiq
-# description: Runs unicorn and sidekiq for nginx integration.
+# description: Runs sidekiq for nginx integration.
 
 # Related (kudos @4sak3n0ne):
 # https://github.com/gitlabhq/gitlabhq/issues/1049#issuecomment-8386882


### PR DESCRIPTION
I'm using Phusion Passenger to serve gitlab and I think someone else could need a clean init.d script to serve his gitlab instance.
