### PR TITLE
[Guide] GitLab 6.4 - CentOS 6.5 - Update GitLab and Ruby versions

### DIFF
--- a/install/centos/README.md
+++ b/install/centos/README.md
@@ -186,8 +186,8 @@ Download and compile it:
 
     su -
     mkdir /tmp/ruby && cd /tmp/ruby
-    curl --progress ftp://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p353.tar.gz | tar xz
-    cd ruby-2.0.0-p353
+    curl --progress ftp://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0.tar.gz | tar xz
+    cd ruby-2.1.0
     ./configure --prefix=/usr/local/
     make && make install
 
@@ -197,7 +197,7 @@ installed with:
     which ruby
     # /usr/local/bin/ruby
     ruby -v
-    # ruby 2.0.0p353 (2013-11-22 revision 43784) [x86_64-linux]
+    # ruby 2.1.0p0 (2013-12-25 revision 44422) [x86_64-linux]
 
 Install the Bundler Gem:
 


### PR DESCRIPTION
Incremented versions:
GitLab 6.3 -> 6.4
Ruby 2.0 -> 2.1
