### PR TITLE
don't need to disable gravatar, actually use ssl_url

### DIFF
--- a/web-server/nginx/gitlab-ssl
+++ b/web-server/nginx/gitlab-ssl
@@ -12,9 +12,9 @@
 # Also you need to edit gitlab-shell config.
 # Set "gitlab_url" param in gitlab-shell/config.yml to https://git.example.com 
 # You also need to edit gitlab/config/gitlab.yml
-#  1) Define port for http: port: 443
-#  2) Enable https:         https: true
-#  3) Disable gravatar:     enabled: false
+#  1) Define port for http "port: 443"
+#  2) Enable https "https: true"
+#  3) Update ssl for gravatar "ssl_url: https://secure.gravatar.com/avatar/%{hash}?s=%{size}&d=mm"
 
 upstream gitlab {
 


### PR DESCRIPTION
Just an update on the previous pull request

You was correct to say to use the ssl_url, which resolved the issue for me
