### PR TITLE
User with /sbin/nologin shell now also supported

### DIFF
--- a/init/sysvinit/centos/gitlab-unicorn
+++ b/init/sysvinit/centos/gitlab-unicorn
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # GitLab
-# Contributors  : @elvanja, @troyanov, @eiyaya, @foyo23, @nielsbasjes, @relip, @JasonMing, @andronat, @axilleas
+# Contributors  : @elvanja, @troyanov, @eiyaya, @foyo23, @nielsbasjes, @relip, @JasonMing, @andronat, @axilleas, @mdirkse
 # App Version   : 6.x
 
 # chkconfig: 2345 82 55


### PR DESCRIPTION
The current code doesn't support users that have their shell set to `/sbin/nologin`, a widely used way to make absolutely sure that a particular user can never log in with a terminal.

Currently, the path is set by running a command as a user, but that command is run using the default shell and thus won't work for users with `/sbin/nologin` (ie with no shell).

Explicitly specifying a shell by adding `-s /bin/bash` (using the same shell used to run the init script) solves this problem.
