### PR TITLE
Nginx proxy_pass url does not match general install instructions

### DIFF
--- a/web-server/nginx/gitlab-ssl
+++ b/web-server/nginx/gitlab-ssl
@@ -72,6 +72,6 @@ server {
         proxy_set_header  Host              $http_host;
         proxy_set_header  X-Real-IP         $remote_addr;
 
-        proxy_pass http://gitlab;
+        proxy_pass http://localhost:8080;
     }
 }


### PR DESCRIPTION
The URL does not match the general GitLab install instructions ( https://github.com/gitlabhq/gitlab-recipes/tree/master/install/centos )
