### PR TITLE
Update gitlab-ssl

### DIFF
--- a/web-server/nginx/gitlab-ssl
+++ b/web-server/nginx/gitlab-ssl
@@ -67,10 +67,11 @@ server {
         proxy_connect_timeout 300; # https://github.com/gitlabhq/gitlabhq/issues/694
         proxy_redirect        off;
 
-        proxy_set_header  X-Forwarded-Proto https;
-        proxy_set_header  X-Forwarded-Ssl   on;
-        proxy_set_header  Host              $http_host;
-        proxy_set_header  X-Real-IP         $remote_addr;
+        proxy_set_header   Host              $http_host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-Ssl   on;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
 
         proxy_pass http://gitlab;
     }


### PR DESCRIPTION
IP was not forwarded correctly with the old configuration on my setup, this is working for me.
