### PR TITLE
change in gitlab-shell/config.yml

### DIFF
--- a/install/centos/README.md
+++ b/install/centos/README.md
@@ -293,7 +293,8 @@ GitLab Shell is a ssh access and repository management application developed spe
     sudo -u git -H cp config.yml.example config.yml
 
     # Edit config and replace gitlab_url
-    # with something like 'http://domain.com/'
+    # with something like 'https://domain.com/'
+    # also edit self_signed_cert to true if you are going to use selfsigned cert 
     sudo -u git -H editor config.yml
 
     # Do setup


### PR DESCRIPTION
Because later in this recipe it is suggested to set port 80 to 443 (ssl) redirection I recommend to advice user to set https in config.yml file. It takes me some time to find this as problem when accessing gitlab api (https://github.com/gitlabhq/gitlabhq/issues/3483)
