### PR TITLE
Update apache2.4 for forward secrecy/no compression

### DIFF
--- a/web-server/apache/gitlab-ssl-apache2.4.conf
+++ b/web-server/apache/gitlab-ssl-apache2.4.conf
@@ -22,7 +22,11 @@
   SSLEngine on
   #strong encryption ciphers only
   #see ciphers(1) http://www.openssl.org/docs/apps/ciphers.html
-  SSLCipherSuite SSLv3:TLSv1:+HIGH:!SSLv2:!MD5:!MEDIUM:!LOW:!EXP:!ADH:!eNULL:!aNULL
+  SSLProtocol all -SSLv2
+  SSLHonorCipherOrder on
+  SSLCipherSuite "ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS"
+  Header add Strict-Transport-Security: "max-age=15768000;includeSubdomains"
+  SSLCompression Off
   SSLCertificateFile /etc/httpd/ssl.crt/gitlab.example.com.crt
   SSLCertificateKeyFile /etc/httpd/ssl.key/gitlab.example.com.key
   SSLCACertificateFile /etc/httpd/ssl.crt/your-ca.crt


### PR DESCRIPTION
Adds forward secrecy and disables SSL/TLS compression which is potentially exploitable. Also updates the cyphers.
