### PR TITLE
Minor gitlab-ssl guide fixes

### DIFF
--- a/web-server/nginx/gitlab-ssl
+++ b/web-server/nginx/gitlab-ssl
@@ -20,12 +20,12 @@
 ## [Optional] Generate a self-signed ssl certificate:
 ##    mkdir /etc/nginx/ssl/
 ##    cd /etc/nginx/ssl/
-##    sudo openssl req -new rsa:2048 -x509 -nodes -days 3560 -out gitlab.crt -keyout gitlab.key
+##    sudo openssl req -newkey rsa:2048 -x509 -nodes -days 3560 -out gitlab.crt -keyout gitlab.key
 ##    sudo chmod o-r gitlab.key
 ##
 ## Edit `gitlab-shell/config.yml`:
 ##  1) Set "gitlab_url" param in `gitlab-shell/config.yml` to `https://git.example.com`
-##  2) Set "ca_file" to `/etc/nginx/gitlab.crt`
+##  2) Set "ca_file" to `/etc/nginx/ssl/gitlab.crt`
 ##  3) Set "self_signed_cert" to `true`
 ## Edit `gitlab/config/gitlab.yml`:
 ##  1) Define port for http "port: 443"


### PR DESCRIPTION
I was using your handy guide, and it looks like there's a small error in the SSL certificate generation code, as well as a mistyped path.
