### PR TITLE
[Apache] Keep slashes encoded for API

### DIFF
--- a/web-server/apache/gitlab-apache2.4.conf
+++ b/web-server/apache/gitlab-apache2.4.conf
@@ -10,6 +10,10 @@
 
   ProxyPreserveHost On
 
+  # Ensure that encoded slashes are not decoded but left in their encoded state.
+  # http://doc.gitlab.com/ce/api/projects.html#get-single-project
+  AllowEncodedSlashes NoDecode
+
   <Location />
     # New authorization commands for apache 2.4 and up
     # http://httpd.apache.org/docs/2.4/upgrading.html#access

--- a/web-server/apache/gitlab-ssl-apache2.4.conf
+++ b/web-server/apache/gitlab-ssl-apache2.4.conf
@@ -36,6 +36,10 @@
 
   ProxyPreserveHost On
 
+  # Ensure that encoded slashes are not decoded but left in their encoded state.
+  # http://doc.gitlab.com/ce/api/projects.html#get-single-project
+  AllowEncodedSlashes NoDecode
+
   <Location />
     # New authorization commands for apache 2.4 and up
     # http://httpd.apache.org/docs/2.4/upgrading.html#access

--- a/web-server/apache/gitlab-ssl.conf
+++ b/web-server/apache/gitlab-ssl.conf
@@ -32,6 +32,10 @@
 
   ProxyPreserveHost On
 
+  # Ensure that encoded slashes are not decoded but left in their encoded state.
+  # http://doc.gitlab.com/ce/api/projects.html#get-single-project
+  AllowEncodedSlashes NoDecode
+
   <Location />
     Order deny,allow
     Allow from all

--- a/web-server/apache/gitlab.conf
+++ b/web-server/apache/gitlab.conf
@@ -10,6 +10,10 @@
 
   ProxyPreserveHost On
 
+  # Ensure that encoded slashes are not decoded but left in their encoded state.
+  # http://doc.gitlab.com/ce/api/projects.html#get-single-project
+  AllowEncodedSlashes NoDecode
+
   <Location />
     Order deny,allow
     Allow from all


### PR DESCRIPTION
> If using namespaced projects call make sure that the NAMESPACE/PROJECT_NAME
> is URL-encoded, eg. /api/v3/projects/diaspora%2Fdiaspora 
> (where / is represented by %2F).

http://doc.gitlab.com/ce/api/projects.html#get-single-project
