### PR TITLE
fix giblab start error, log is : Errno::EACCES: Permission denied - conn...

### DIFF
--- a/install/centos/README.md
+++ b/install/centos/README.md
@@ -414,6 +414,7 @@ Disable Redis listening on TCP by setting 'port' to 0:
 Enable Redis socket for default CentOS path:
 
     echo 'unixsocket /var/run/redis/redis.sock' | sudo tee -a /etc/redis.conf
+    echo -e 'unixsocketperm 0775' | sudo tee -a /etc/redis.conf
 
 Activate the changes to redis.conf:
 


### PR DESCRIPTION
error log:

== Seed from /home/git/gitlab/db/fixtures/production/001_admin.rb
2014-11-08T15:52:20Z 25461 TID-otwilgzbo INFO: Sidekiq client with redis options {:url=>"unix:/var/run/redis/redis.sock", :namespace=>"resque:gitlab"}
rake aborted!

Errno::EACCES: Permission denied - connect(2) for /var/run/redis/redis.sock
