### PR TITLE
[GitHub import script] improvements

### DIFF
--- a/import/github/import_all.rb
+++ b/import/github/import_all.rb
@@ -79,6 +79,8 @@ gh_repos.each do |gh_r|
   else
     git_repo = Git.clone(gh_r.git_url, gh_r.name, :path => '/tmp/clones')
   end
+  
+  `for branch in $(git --git-dir /tmp/clones/#{gh_r.name}/.git branch -a | grep remotes | grep -v HEAD | grep -v master); do git --git-dir /tmp/clones/#{gh_r.name}/.git branch --track ${branch##*/} $branch;  done`
 
   #
   ## Push the cloned repo to gitlab
@@ -108,7 +110,7 @@ gh_repos.each do |gh_r|
   #create and push the project to GitLab
   new_project = gl_client.create_project(name)
   git_repo.add_remote("gitlab", new_project.ssh_url_to_repo)
-  git_repo.push('gitlab')
+  git_repo.push('gitlab', '--all')
 
   #
   ## Look for issues in GitHub for this project and push them to GitLab

--- a/import/github/import_all.rb
+++ b/import/github/import_all.rb
@@ -21,14 +21,20 @@ options = {:usr => nil,
            :gitlab_token => 'secret'
            }
 optparse = OptionParser.new do |opts|
-  opts.on('-u', '--user USER', "user to connect to github with") do |u|
+  opts.on('-u', '--user USER', "user to connect to GitHub with") do |u|
     options[:usr] = u
   end
-  opts.on('-p', '--pw PASSWORD', 'password for user to connect to github with') do |p|
+  opts.on('-p', '--pw PASSWORD', 'password for user to connect to GitHub with') do |p|
     options[:pw] = p
   end
-  opts.on('--api', 'API endpoint for github') do |a|
+  opts.on('--api API', String, 'API endpoint for GitHub') do |a|
     options[:api] = a
+  end
+  opts.on('--gitlab-api API', String, 'API endpoint for GitLab') do |a|
+    options[:gitlab_api] = a
+  end
+  opts.on('-t', '--gitlab-token TOKEN', String, 'Private token for GitLab') do |t|
+    options[:gitlab_token] = t
   end
   opts.on('--web', 'Web endpoint for GitHub') do |w|
     options[:web] = w

--- a/import/github/import_all.rb
+++ b/import/github/import_all.rb
@@ -134,6 +134,12 @@ gh_repos.each do |gh_r|
   new_project = gl_client.create_project(name)
   git_repo.add_remote("gitlab", new_project.ssh_url_to_repo)
   git_repo.push('gitlab', '--all')
+  
+  # Copy labels for this project
+  labels = gh_client.labels(gh_r.full_name)
+  labels.each do |l|
+    gl_client.create_label(new_project.id, l.name, '#'+l.color)
+  end
 
   #
   ## Look for issues in GitHub for this project and push them to GitLab
@@ -150,7 +156,8 @@ gh_repos.each do |gh_r|
           body += "\n\n#{c.body}\nBy #{c.user.login} on #{c.created_at}"
         end
       end
-      gl_issue = gl_client.create_issue(new_project.id, i.title, :description => body)
+      labels = i.labels.map {|l| l.name }.join(sep=',')
+      gl_issue = gl_client.create_issue(new_project.id, i.title, :description => body, :labels => labels)
     end
   end
 

--- a/import/github/import_all.rb
+++ b/import/github/import_all.rb
@@ -13,9 +13,8 @@ require 'pp'
 #deal with options from cli, like username and pw
 options = {:usr => nil,
            :pw => nil,
-           :api => 'https://github.com/api/v3',
+           :api => 'https://api.github.com',
            :web => 'https://github.com/',
-           :enterprise => true,
            :space => nil,
            :group => nil,
            :ssh => false,
@@ -76,12 +75,9 @@ if options[:group].nil?
   options[:group] = options[:space]
 end
 
-#setup octokit to deal with github enterprise
-if options[:enterprise]
-  Octokit.configure do |c|
-    c.api_endpoint = options[:api]
-    c.web_endpoint = options[:web]
-  end
+Octokit.configure do |c|
+  c.api_endpoint = options[:api]
+  c.web_endpoint = options[:web]
 end
 
 #set the gitlab options


### PR DESCRIPTION
Improvements:
* Import all branches of source repositories (not only default)
* Import labels
* Import all issues (include closed) in correct order, keeps issue numbers (important when mentioning issues)

New CLI parameters:
* group - Destination GitLab project group
* private - Import only private projects
* ssh - Use ssh for GitHub access (needed for private parameter)
* gitlab-api - API endpoint of GitLab
* gitlab-token - GitLab private token