### PR TITLE
[Update] FreeBSD - freebsd-10.md

### DIFF
--- a/install/freebsd/freebsd-10.md
+++ b/install/freebsd/freebsd-10.md
@@ -312,7 +312,7 @@ Edit `/usr/local/etc/nginx/conf.d/gitlab.conf` and replace `git.example.com` wit
 
 Add `nginx` user to `git` group:
 
-    usermod -a -G git nginx
+    pw usermod -a -G git nginx
     chmod g+rx /home/git/
 
 Finally start nginx with:
@@ -375,6 +375,8 @@ Install the Kerberos package: `pkg install krb5`. As far as I know, there's no
 way to disable the Kerberos authentication in GitLab (even if it's unused) so
 unfortunately the only solution is to install the missing packages.
 
+EDIT: The new version of timfel-krb5-auth fails to build even with `krb5` installed. The only solution is to change the package version to `0.8.2`. [(More info here)](https://github.com/gitlabhq/gitlabhq/issues/8478#issuecomment-71328552)
+
 
 Postfix/sendmail: "postdrop: warning: unable to look up public/pickup: No such file or directory"
 -------------------------------------------------------------------------------------------------
@@ -405,6 +407,14 @@ sudo service nginx restart
 ```
 [(Source)](http://www.cyberciti.biz/faq/failed-to-enable-the-httpready-accept-filter/)
 
+PostgreSQL: "FATAL: could not create shared memory segment: Function not implemented"
+-------------------------------------------------------------------------------------
+
+You're trying to run PostgreSQL in a FreeBSD jail, which needs some sysctl tweaks. Set the following options in your jail's config (assuming you're using ezjail):
+```
+export jail_**MY_JAIL_NAME**_parameters="allow.raw_sockets=1 allow.sysvipc=1"
+```
+[(Source)](https://dan.langille.org/2013/07/09/fatal-could-not-create-shared-memory-segment-function-not-implemented/)
 
 References
 ==========


### PR DESCRIPTION
During the installation of GitLab 7.7 I recognized various minor problems with FreeBSD (10.1) in a jail and a new gem version of timfel-krb5-auth. Also the command for usermod was wrong ([see](https://www.freebsd.org/cgi/man.cgi?query=pw&sektion=8))