### PR TITLE
Update Apache recipe for Omnibus

### DIFF
--- a/web-server/apache/omnibus-apache-2.4.conf
+++ b/web-server/apache/omnibus-apache-2.4.conf
@@ -1,0 +1,70 @@
+# This section is only needed if you want to redirect http traffic to https.
+# You can live without it but clients will have to type in https:// to reach gitlab.
+<VirtualHost *:80>
+    ServerName git.example.com
+    ServerSignature Off
+
+    RewriteEngine on
+    RewriteCond %{HTTPS} !=on
+    RewriteRule .* https://%{SERVER_NAME}%{REQUEST_URI} [NE,R,L]
+</VirtualHost>
+
+<VirtualHost *:443>
+    SSLEngine on
+    #strong encryption ciphers only
+    #see ciphers(1) http://www.openssl.org/docs/apps/ciphers.html
+    SSLCipherSuite SSLv3:TLSv1:+HIGH:!SSLv2:!MD5:!MEDIUM:!LOW:!EXP:!ADH:!eNULL:!aNULL
+    SSLCertificateFile /etc/apache2/ssl.crt/example.crt
+    SSLCertificateKeyFile /etc/apache2/ssl.key/example.plain.key
+    SSLCACertificateFile /etc/apache2/ssl.crt/sub.class2.server.ca.pem
+
+    ServerName git.example.com
+    ServerSignature Off
+
+    ProxyRequests Off
+    ProxyPreserveHost On
+
+    # Ensure that encoded slashes are not decoded but left in their encoded state.
+    # http://doc.gitlab.com/ce/api/projects.html#get-single-project
+    AllowEncodedSlashes NoDecode
+
+    # here we don't want to proxify the requests for the existing assets in gitlab's public directory
+    ProxyPassMatch ^(/[^/]+\.(html|png|ico|css|txt))$ !
+    ProxyPass /assets !
+
+    # here we "redirect" the requests for http://git.example.com/ to http://127.0.0.1:8080/
+    ProxyPass / http://127.0.0.1:8080/
+
+    # here we "rewrite" the redirections form unicorn for http://127.0.0.1:8080/ into http://git.example.com/
+    ProxyPassReverse / https://git.example.com/
+
+    DocumentRoot /opt/gitlab/embedded/service/gitlab-rails/public
+
+    <Directory /opt/gitlab/embedded/service/gitlab-rails/public>
+        Require all granted
+    </Directory>
+
+    <Location />
+        Require all granted
+    </Location>
+
+    #apache equivalent of nginx try files
+    # http://serverfault.com/questions/290784/what-is-apaches-equivalent-of-nginxs-try-files
+    # http://stackoverflow.com/questions/10954516/apache2-proxypass-for-rails-app-gitlab
+    RewriteEngine on
+    RewriteCond %{DOCUMENT_ROOT}/%{REQUEST_FILENAME} !-f
+    RewriteRule .* http://127.0.0.1:8080%{REQUEST_URI} [P,QSA]
+    RequestHeader set X_FORWARDED_PROTO 'https'
+
+    #Set up apache error documents, if back end goes down (i.e. 503 error) then a maintenance/deploy page is thrown up.
+    ErrorDocument 404 /404.html
+    ErrorDocument 422 /422.html
+    ErrorDocument 500 /500.html
+    ErrorDocument 503 /deploy.html
+
+    LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b" common_forwarded
+    ErrorLog  /var/log/apache2/gitlab_error.log
+    CustomLog /var/log/apache2/gitlab_forwarded.log common_forwarded
+    CustomLog /var/log/apache2/gitlab_access.log combined env=!dontlog
+    CustomLog /var/log/apache2/gitlab.log combined
+</VirtualHost>


### PR DESCRIPTION
The suggested configuration here does not work for the Omnibus installation as some of the folders have changed. This file works for me on Ubuntu 14.04 LTS with Omnibus 1.1 for Gitlab 7.9.1 - when this works, the nginx web server is not needed anymore and can be disabled in gitlab.rb, as well as setting the url to https://git.example.com, like so

external_url 'https://git.moodsdesign.com'
nginx['enable'] = false