### PR TITLE
systemd: create new unit for gitlab-git-http-server.

### DIFF
--- a/init/systemd/README.md
+++ b/init/systemd/README.md
@@ -17,6 +17,7 @@ sudo su
 cd /etc/systemd/system/
 wget -O gitlab-sidekiq.service https://gitlab.com/gitlab-org/gitlab-recipes/raw/master/init/systemd/gitlab-sidekiq.service
 wget -O gitlab-unicorn.service https://gitlab.com/gitlab-org/gitlab-recipes/raw/master/init/systemd/gitlab-unicorn.service
+wget -O gitlab-git-http.service https://gitlab.com/gitlab-org/gitlab-recipes/raw/master/init/systemd/gitlab-git-http.service
 ```
 
 Reload systemd:
@@ -25,11 +26,11 @@ Reload systemd:
 
 Start the services:
 
-    sudo systemctl start gitlab-sidekiq.service gitlab-unicorn.service
+    sudo systemctl start gitlab-sidekiq.service gitlab-unicorn.service gitlab-git-http.service
 
 Enable them to start at boot:
 
-    sudo systemctl enable gitlab-sidekiq.service gitlab-unicorn.service
+    sudo systemctl enable gitlab-sidekiq.service gitlab-unicorn.service gitlab-git-http.service
 
 ## Notes
 

--- a/init/systemd/gitlab-git-http.service
+++ b/init/systemd/gitlab-git-http.service
@@ -1,0 +1,25 @@
+#####################################################
+#
+# GitLab version    : 8.x - 8.x
+# Contributors      : davispuh, mtorromeo, axilleas, boeserwolf91, Stefan Tatschner (rumpelsepp)
+# Downloaded from   : https://gitlab.com/gitlab-org/gitlab-recipes/tree/master/init/systemd
+#
+####################################################
+
+[Unit]
+Description=Gitlab Git HTTP Worker
+Requires=gitlab-unicorn.service
+Wants=gitlab-unicorn.service
+After=gitlab-unicorn.service
+
+[Service]
+Type=forking
+User=git
+WorkingDirectory=/home/git/gitlab-git-http-server
+SyslogIdentifier=gitlab-git-http-server
+PIDFile=/home/git/gitlab/tmp/pids/gitlab-git-http-server.pid
+
+ExecStart=/home/git/gitlab/bin/daemon_with_pidfile /home/git/gitlab/tmp/pids/gitlab-git-http-server.pid /home/git/gitlab-git-http-server/gitlab-git-http-server -listenUmask 0 -listenNetwork unix -listenAddr /home/git/gitlab/tmp/sockets/gitlab-git-http-server.socket -authBackend http://127.0.0.1:8080 /home/git/repositories >> /home/git/gitlab/log/gitlab-git-http-server.log 2>&1
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This service is required for HTTP(S) push and pull operations from 8.0
and presumably onwards.