### PR TITLE
Fix RewriteCond in GitLab 8.0 Apache 2.4 example

### DIFF
--- a/web-server/apache/gitlab-8.0-apache2.4.conf
+++ b/web-server/apache/gitlab-8.0-apache2.4.conf
@@ -31,7 +31,7 @@
   # http://stackoverflow.com/questions/10954516/apache2-proxypass-for-rails-app-gitlab
   RewriteEngine on
   #Forwad request ending with .git to gitlab-git-http-server
-  RewriteCond %{REQUEST_URI} .*\.(git)
+  RewriteCond %{REQUEST_URI} ^(?:\/[\w-_.]+){2}\.(git)(?!\w)
   RewriteRule .* http://127.0.0.1:8181%{REQUEST_URI} [P,QSA]
 
   #Forwad forward any other requests to GitLab Rails app (Unicorn) 

--- a/web-server/apache/gitlab-8.0-ssl-apache2.4.conf
+++ b/web-server/apache/gitlab-8.0-ssl-apache2.4.conf
@@ -57,7 +57,7 @@
   # http://stackoverflow.com/questions/10954516/apache2-proxypass-for-rails-app-gitlab
   RewriteEngine on
   #Forwad request ending with .git to gitlab-git-http-server
-  RewriteCond %{REQUEST_URI} .*\.(git)
+  RewriteCond %{REQUEST_URI} ^(?:\/[\w-_.]+){2}\.(git)(?!\w)
   RewriteRule .* http://127.0.0.1:8181%{REQUEST_URI} [P,QSA]
 
   #Forwad forward any other requests to GitLab Rails app (Unicorn) 


### PR DESCRIPTION
Allows viewing files starting with '.git' (ex: .gitignore, .gitkeep) in GitLab web interface.

``"GET /some-namespace/some-project/blob/master/.gitignore HTTP/1.1" 403 10``

[here is a regex test case for the original regex](https://regex101.com/r/lZ3hT1/1)

If changed to: ``^(?:\/[\w-_.]+){2}\.(git)(?!\w)``

This will ensure there are at least 2 directories; the second one ending in '.git'. We can use a negative look ahead for good measure; ensuring we aren't falsely matching a project with the name '.git' in it.

[here is a regex test case](https://regex101.com/r/lR0yE5/2)