### PR TITLE
systemd: add unit for gitlab-workhorse.

### DIFF
--- a/init/systemd/README.md
+++ b/init/systemd/README.md
@@ -6,6 +6,7 @@ GitLab requires a couple of services:
 * Mail server (postfix or other)
 * GitLab Sidekiq service (`gitlab-sidekiq.service`)
 * Unicorn service (`gitlab-unicorn.service`)
+* Gitlab Workhorse server for slow HTTP requests (`gitlab-workhorse.service`)
 
 
 ## Setup GitLab services
@@ -17,7 +18,7 @@ sudo su
 cd /etc/systemd/system/
 wget -O gitlab-sidekiq.service https://gitlab.com/gitlab-org/gitlab-recipes/raw/master/init/systemd/gitlab-sidekiq.service
 wget -O gitlab-unicorn.service https://gitlab.com/gitlab-org/gitlab-recipes/raw/master/init/systemd/gitlab-unicorn.service
-wget -O gitlab-git-http.service https://gitlab.com/gitlab-org/gitlab-recipes/raw/master/init/systemd/gitlab-git-http.service
+wget -O gitlab-workhorse.service https://gitlab.com/gitlab-org/gitlab-recipes/raw/master/init/systemd/gitlab-workhorse.service
 wget -O gitlab-mailroom.service https://gitlab.com/gitlab-org/gitlab-recipes/raw/master/init/systemd/gitlab-mailroom.service
 ```
 
@@ -27,14 +28,16 @@ Reload systemd:
 
 Start the services:
 
-    sudo systemctl start gitlab-sidekiq.service gitlab-unicorn.service gitlab-git-http.service gitlab-mailroom.service
+    sudo systemctl start gitlab-sidekiq.service gitlab-unicorn.service gitlab-workhorse.service gitlab-mailroom.service
 
 Enable them to start at boot:
 
-    sudo systemctl enable gitlab-sidekiq.service gitlab-unicorn.service gitlab-git-http.service gitlab-mailroom.service
+    sudo systemctl enable gitlab-sidekiq.service gitlab-unicorn.service gitlab-workhorse.service gitlab-mailroom.service
 
 ## Notes
 
 * If you installed GitLab in other path than `/home/git/gitlab` change the service files accordingly.
 
 * `/etc/systemd/system/` have a higher precedence over  `/usr/lib/systemd/system`.
+
+* If you are running Gitlab 8.0-8.1, use `gitlab-git-http-server.service` instead of `gitlab-workhorse.service`.

--- a/init/systemd/gitlab-git-http.service
+++ b/init/systemd/gitlab-git-http.service
@@ -1,6 +1,6 @@
 #####################################################
 #
-# GitLab version    : 8.x - 8.x
+# GitLab version    : 8.0 - 8.1
 # Contributors      : davispuh, mtorromeo, axilleas, boeserwolf91, Stefan Tatschner (rumpelsepp)
 # Downloaded from   : https://gitlab.com/gitlab-org/gitlab-recipes/tree/master/init/systemd
 #

--- a/init/systemd/gitlab-workhorse.service
+++ b/init/systemd/gitlab-workhorse.service
@@ -1,0 +1,25 @@
+#####################################################
+#
+# GitLab version    : 8.2 - 8.x
+# Contributors      : bjorn-oivind
+# Downloaded from   : https://gitlab.com/gitlab-org/gitlab-recipes/tree/master/init/systemd
+#
+####################################################
+
+[Unit]
+Description=Gitlab Workhorse handles slow HTTP requests for Gitlab.
+Requires=gitlab-unicorn.service
+Wants=gitlab-unicorn.service
+After=gitlab-unicorn.service
+
+[Service]
+Type=forking
+User=git
+WorkingDirectory=/home/git/gitlab-workhorse
+SyslogIdentifier=gitlab-workhorse
+PIDFile=/home/git/gitlab/tmp/pids/gitlab-workhorse.pid
+
+ExecStart=/home/git/gitlab/bin/daemon_with_pidfile /home/git/gitlab/tmp/pids/gitlab-workhorse.pid /home/git/gitlab-workhorse/gitlab-workhorse -listenUmask 0 -listenNetwork unix -listenAddr /home/git/gitlab/tmp/sockets/gitlab-workhorse.socket -authBackend http://127.0.0.1:8080 >> /home/git/gitlab/log/gitlab-workhorse.log 2>&1
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Please note that this deprecates the gitlab-git-http-server used for
8.0-8.1. Gitlab Workhorse is used from 8.2 and hopefully onwards.