### PR TITLE
caddy: disable fail_timeout by default

### DIFF
--- a/web-server/caddy/Caddyfile
+++ b/web-server/caddy/Caddyfile
@@ -12,7 +12,7 @@ https://gitlab.example.com {
     }
 
     proxy / http://127.0.0.1:8181 {
-        fail_timeout 300s
+        fail_timeout 0s
 
         header_upstream Host {host}
         header_upstream X-Real-IP {remote}


### PR DESCRIPTION
gitlab has 502 errors quite frequently (workhorse / unicorn problems?) and caching the failure is not helpful, so this should probably stay disabled.