### PR TITLE
[web-server] caddy GitLab Pages configuration

### DIFF
--- a/web-server/caddy/Caddyfile
+++ b/web-server/caddy/Caddyfile
@@ -20,3 +20,14 @@ https://gitlab.example.com {
         header_upstream X-Forwarded-Ssl on
     }
 }
+
+# Optional GitLab Pages config
+*.example.io {
+    tls {
+        max_certs 10
+    }
+    proxy / http://127.0.0.1:8090 {
+        fail_timeout 0s
+        transparent
+    }
+}

--- a/web-server/caddy/README.md
+++ b/web-server/caddy/README.md
@@ -2,6 +2,8 @@
 
 This is an example configuration of how to use GitLab with [caddy](https://caddyserver.com/).
 
+## GitLab
+
 ### Updating GitLab Configuration
 
 Open `/etc/gitlab/gitlab.rb` using your favourite text editor and update the following values.
@@ -16,3 +18,23 @@ Open `/etc/gitlab/gitlab.rb` using your favourite text editor and update the fol
 ### Updating the Caddyfile
 
 Simply change gitlab.example.com to point to your FQDN.
+
+## GitLab Pages
+
+### Updating GitLab Configuration
+
+Change `https://example.io` to point to your pages domain:
+
+```ruby
+pages_external_url "https://example.io"
+
+gitlab_pages['enable'] = true
+gitlab_pages['listen_proxy'] = "127.0.0.1:8090"
+gitlab_pages['redirect_http'] = true
+gitlab_pages['use_http2'] = true
+gitlab_pages['metrics_address'] = ":9235"
+```
+
+### Updating the Caddyfile
+
+Simply change `*.example.io` to point to your pages domain (must be different from you GitLab domain).


### PR DESCRIPTION
Tested on Ubuntu 16.04.2, GitLab 8.17.0, Caddy 0.9.3.